### PR TITLE
clean up playbook

### DIFF
--- a/install_agent.yaml
+++ b/install_agent.yaml
@@ -1,9 +1,13 @@
 ---
- - hosts: zabbix-hosts
-   become: true
-   tasks:
+- hosts: zabbix-hosts
+  become: true
+  vars:
+    zabbix_agent_type: passive
+
+  tasks:
     - name: Install the RPM for x86_64
-      yum: name=http://repo.zabbix.com/zabbix/4.0/rhel/7/x86_64/zabbix-release-4.0-1.el7.noarch.rpm
+      yum:
+        name: http://repo.zabbix.com/zabbix/4.0/rhel/7/x86_64/zabbix-release-4.0-1.el7.noarch.rpm
       when: ansible_architecture == "x86_64"
 
     - name: Copy the repo file for ppc64le zabbix agent.
@@ -16,15 +20,14 @@
       yum:
         name: zabbix-agent
         state: latest
-        update_cache: yes
+        update_cache: true
 
-    - name: Copy zabbix agent configuration file from github
-      get_url:
-        url: https://raw.githubusercontent.com/CCI-MOC/zabbix-config/master/agent_config_files/{{ agent_type | default('passive') }}.conf
+    - name: Install zabbix agent configuration
+      copy:
+        src: agent_config_files/{{ zabbix_agent_type }}.conf
         dest: /etc/zabbix/zabbix_agentd.conf
-        force: yes
       notify:
-       - Restart Zabbix
+        - Restart Zabbix
 
     - name: Start and enable zabbix agent
       service:
@@ -32,7 +35,7 @@
         state: started
         enabled: yes
 
-   handlers:
+  handlers:
     - name: Restart Zabbix
       service:
         name: zabbix-agent


### PR DESCRIPTION
- use zabbix_agent_type instead of agent_type, because namespacing
  your variables will make your life easier down the road.

- set a default using a vars: block rather than the default() filter.

- fix indentation to match standard yaml formatting (initial "-" in
  "- hosts" should be in column 0, etc)

- use yaml syntax for specifying module parameters.  Instead of "yum:
  name=...", provide parameters to yum module as a yaml dictionary.

- use copy instead of get_url.  we already have the repository checked
  out if we're using this playbook, so just use the copy module
  instead of fetching the config from github using get_url.