### PR TITLE
Specify the Local address in the `Server=` directive to allow local c…

### DIFF
--- a/zabbix_agentd.conf
+++ b/zabbix_agentd.conf
@@ -2,7 +2,7 @@ PidFile=/var/run/zabbix/zabbix_agentd.pid
 LogFile=/var/log/zabbix/zabbix_agentd.log
 LogFileSize=0
 
-Server=zabbix.massopen.cloud
+Server=zabbix.massopen.cloud,172.16.0.203
 ServerActive=zabbix.massopen.cloud
 
 User=zabbix


### PR DESCRIPTION
…onnections

from the server otherwise the agents will only listen on the public ip.

I tested this on one of the compute hosts and this seems to do the trick.